### PR TITLE
Add effect-3.0.4 mod to remove gen adapter

### DIFF
--- a/.changeset/slimy-years-exist.md
+++ b/.changeset/slimy-years-exist.md
@@ -1,0 +1,19 @@
+---
+"@effect/codemod": patch
+---
+
+Add effect-3.0.4 mod to remove gen adapter
+
+NOTE: some edge cases are uncovered like:
+
+```ts
+yield* $([Effect.succeed(0), Effect.succeed(1)] as const, Effect.allWith())
+```
+
+that needs to be convered to:
+
+```ts
+yield* pipe([Effect.succeed(0), Effect.succeed(1)] as const, Effect.allWith())
+```
+
+Unfortunately not having type information in the mod tool renders impossible to decide if the `pipe` function is present or not.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true

--- a/public/codemods/effect-3.0.4.ts
+++ b/public/codemods/effect-3.0.4.ts
@@ -1,0 +1,38 @@
+import type cs from "jscodeshift"
+
+export default function transformer(file: cs.FileInfo, api: cs.API) {
+  const j = api.jscodeshift
+  const root = j(file.source)
+
+  root.find(j.CallExpression).forEach((call) => {
+    if (call.node.callee.type === "MemberExpression" && call.node.callee.property.type === "Identifier" && call.node.callee.property.name === "gen") {
+      if (call.node.arguments.length > 0 && call.node.arguments.length <= 2) {
+        const arg = call.node.arguments[call.node.arguments.length - 1]
+        if (arg.type === "FunctionExpression" && arg.generator === true && arg.params.length === 1 && arg.params[0].type === "Identifier") {
+          const adapter = arg.params[0].name
+          arg.params = []
+          j(arg.body).find(j.YieldExpression).forEach((yieldExpr) => {
+            if (yieldExpr.node.argument?.type === "CallExpression") {
+              const call = yieldExpr.node.argument
+              if (call.callee.type === "Identifier" && call.callee.name === adapter) {
+                if (call.arguments.length === 1 && call.arguments[0].type !== "SpreadElement") {
+                  yieldExpr.node.argument = call.arguments[0]
+                } else if (call.arguments.length > 1 && call.arguments[0].type !== "SpreadElement") {
+                  yieldExpr.node.argument = j.callExpression(
+                    j.memberExpression(
+                      call.arguments[0],
+                      j.identifier("pipe")
+                    ),
+                    call.arguments.slice(1)
+                  )
+                }
+              }
+            }
+          })
+        }
+      }
+    }
+  })
+
+  return root.toSource()
+}


### PR DESCRIPTION
NOTE: some edge cases are uncovered like:

```ts
yield* $([Effect.succeed(0), Effect.succeed(1)] as const, Effect.allWith())
```

that needs to be convered to:

```ts
yield* pipe([Effect.succeed(0), Effect.succeed(1)] as const, Effect.allWith())
```

Unfortunately not having type information in the mod tool renders impossible to decide if the `pipe` function is present or not.
