### PR TITLE
Fix: Update import from `formatError` to `formatErrorSync` in the sch…

### DIFF
--- a/.changeset/twelve-seas-float.md
+++ b/.changeset/twelve-seas-float.md
@@ -1,0 +1,5 @@
+---
+"@effect/codemod": patch
+---
+
+Fix: Update import from `formatError` to `formatErrorSync` in the schema 0.65 codemod, closes #36

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "access": "public",
     "directory": "dist"
   },
-  "packageManager": "pnpm@8.12.1",
+  "packageManager": "pnpm@9.0.4",
   "description": "Code mod's for the Effect ecosystem",
   "engines": {
     "node": ">=16.17.1"

--- a/test/schema-0.65.test.ts
+++ b/test/schema-0.65.test.ts
@@ -363,7 +363,43 @@ class C extends A.transformOrFailFrom<C>("C")({ b: Schema.Number }, {
 
 describe("TreeFormatter", () => {
   expectTransformation(
-    "formatIssue / formatIssueEffect",
+    `import { formatError } from "@effect/schema/TreeFormatter"`,
+    `import { formatError } from "@effect/schema/TreeFormatter"
+
+formatError(ParseResult.parseError(err))`,
+    `import { formatErrorSync } from "@effect/schema/TreeFormatter"
+
+formatErrorSync(ParseResult.parseError(err))`,
+  )
+
+  expectTransformation(
+    `import { formatErrorEffect } from "@effect/schema/TreeFormatter"`,
+    `import { formatErrorEffect } from "@effect/schema/TreeFormatter"
+
+formatErrorEffect(ParseResult.parseError(err))`,
+    `import { formatError } from "@effect/schema/TreeFormatter"
+
+formatError(ParseResult.parseError(err))`,
+  )
+
+  expectTransformation(
+    `import { formatError, formatErrorEffect } from "@effect/schema/TreeFormatter"`,
+    `import { formatError, formatErrorEffect } from "@effect/schema/TreeFormatter"
+
+formatError(ParseResult.parseError(err1))
+formatErrorEffect(ParseResult.parseError(err2))
+formatError(ParseResult.parseError(err3))
+formatErrorEffect(ParseResult.parseError(err4))`,
+    `import { formatErrorSync, formatError } from "@effect/schema/TreeFormatter"
+
+formatErrorSync(ParseResult.parseError(err1))
+formatError(ParseResult.parseError(err2))
+formatErrorSync(ParseResult.parseError(err3))
+formatError(ParseResult.parseError(err4))`,
+  )
+
+  expectTransformation(
+    "TreeFormatter.formatIssue / TreeFormatter.formatIssueEffect",
     `import { ParseResult, Schema, TreeFormatter } from "@effect/schema"
 
 const message1 = TreeFormatter.formatIssueEffect(
@@ -385,7 +421,7 @@ const message2 = TreeFormatter.formatIssueSync(
   )
 
   expectTransformation(
-    "formatError / formatErrorEffect",
+    "TreeFormatter.formatError / TreeFormatter.formatErrorEffect",
     `import { ParseResult, Schema, TreeFormatter } from "@effect/schema"
 
 const message1 = TreeFormatter.formatErrorEffect(
@@ -409,7 +445,43 @@ const message2 = TreeFormatter.formatErrorSync(
 
 describe("ArrayFormatter", () => {
   expectTransformation(
-    "formatIssue / formatIssueEffect",
+    `import { formatError } from "@effect/schema/ArrayFormatter"`,
+    `import { formatError } from "@effect/schema/ArrayFormatter"
+
+formatError(ParseResult.parseError(err))`,
+    `import { formatErrorSync } from "@effect/schema/ArrayFormatter"
+
+formatErrorSync(ParseResult.parseError(err))`,
+  )
+
+  expectTransformation(
+    `import { formatErrorEffect } from "@effect/schema/ArrayFormatter"`,
+    `import { formatErrorEffect } from "@effect/schema/ArrayFormatter"
+
+formatErrorEffect(ParseResult.parseError(err))`,
+    `import { formatError } from "@effect/schema/ArrayFormatter"
+
+formatError(ParseResult.parseError(err))`,
+  )
+
+  expectTransformation(
+    `import { formatError, formatErrorEffect } from "@effect/schema/ArrayFormatter"`,
+    `import { formatError, formatErrorEffect } from "@effect/schema/ArrayFormatter"
+
+formatError(ParseResult.parseError(err1))
+formatErrorEffect(ParseResult.parseError(err2))
+formatError(ParseResult.parseError(err3))
+formatErrorEffect(ParseResult.parseError(err4))`,
+    `import { formatErrorSync, formatError } from "@effect/schema/ArrayFormatter"
+
+formatErrorSync(ParseResult.parseError(err1))
+formatError(ParseResult.parseError(err2))
+formatErrorSync(ParseResult.parseError(err3))
+formatError(ParseResult.parseError(err4))`,
+  )
+
+  expectTransformation(
+    "ArrayFormatter.formatIssue / ArrayFormatter.formatIssueEffect",
     `import { ParseResult, Schema, ArrayFormatter } from "@effect/schema"
 
 const message1 = ArrayFormatter.formatIssueEffect(
@@ -431,7 +503,7 @@ const message2 = ArrayFormatter.formatIssueSync(
   )
 
   expectTransformation(
-    "formatError / formatErrorEffect",
+    "ArrayFormatter.formatError / ArrayFormatter.formatErrorEffect",
     `import { ParseResult, Schema, ArrayFormatter } from "@effect/schema"
 
 const message1 = ArrayFormatter.formatErrorEffect(


### PR DESCRIPTION
…ema 0.65 codemod, closes #36

<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Closes ##36
